### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Ultimate Starter Kit plugin comes with the following features:
     <li><strong>Logger</strong>: A system used to easily log info to file and via on-screen messages</li>
     <li><strong>Save data management</strong>: A system used to easily save/load game data with support for multiple save slots</li>
     <li><strong>Settings</strong>: A full settings system including both the UI and save/load logic</li>
-    <li><strong>Dialogue System</strong>: A full dialogue system with support for different participants, choices and branches</li>
+    <li><strong>Dialogue System</strong>: A full dialogue system with support for different participants, choices, and branches</li>
     <li><strong>Inventory Management</strong>: Manage multiple inventories with save data integration</li>
     <li><strong>Input Indicators</strong>: A system used to easily detect different input devices and update the UI to display the correct indicators</li>
     <li><strong>Currency</strong>: A system that is used to easily manage different types of currency</li>
@@ -44,11 +44,11 @@ The Ultimate Starter Kit plugin comes with the following features:
             <li>Leaning with procedural animations</li>
         </ul>
     </li>
-    <li><strong>Weapons System</strong>: A customizable weapon system with support for recoil, multiple fire types, fire rates and projectile types</li>
+    <li><strong>Weapons System</strong>: A customizable weapon system with support for recoil, multiple fire types, fire rates, and projectile types</li>
     <li><strong>Menu system</strong>: A customizable menu system with support for controllers and complex menu layouts</li>
     <li><strong>Config Utils</strong>: Extract information from different config files</li>
     <li><strong>Platform Utils</strong>: Easily detect different platform types and architectures</li>
-    <li><strong>Project Utils</strong>: Extract project information like name, description and version</li>
+    <li><strong>Project Utils</strong>: Extract project information like name, description, and version</li>
 </ul>
 
 ## Documentation


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Features**"

"**participants, choices and branches**"  should be "**participants, choices, and branches**"

" **fire types, fire rates and projectile types**"  should be " **fire types, fire rates, and projectile types**"

"**name, description and version..**"  should be "**name, description, and version..**"

Screenshot-

![Screenshot (110)](https://github.com/hfjooste/UltimateStarterKit/assets/114826902/f2489e1e-f614-4026-a5b6-d80ed0561027)
